### PR TITLE
Set of stability fixes

### DIFF
--- a/src/machine_runner.py
+++ b/src/machine_runner.py
@@ -314,9 +314,9 @@ async def handle_inference_data_message(name: str, tensor):
             residual = combined_tensor[1]
             positions = combined_tensor[2]
 
-            print(
-                f"✅ Stored both hidden_state and residual and positions for {request_id} step {step_idx}"
-            )
+            # print(
+            #     f"✅ Stored both hidden_state and residual and positions for {request_id} step {step_idx}"
+            # )
 
             # # Unstack the combined tensor
             # if tensor.shape[0] != 2:
@@ -338,9 +338,9 @@ async def handle_inference_data_message(name: str, tensor):
                 )
                 INFERENCE_CONTEXT[request_id][str(step_idx)]["residual"] = residual
                 INFERENCE_CONTEXT[request_id][str(step_idx)]["positions"] = positions
-                print(
-                    f"✅ Stored both hidden_state and residual and positions for {request_id} step {step_idx}"
-                )
+                # print(
+                #     f"✅ Stored both hidden_state and residual and positions for {request_id} step {step_idx}"
+                # )
 
                 # wake anybody waiting for this step's payload
                 event = STEP_EVENTS[request_id].setdefault(step_idx, threading.Event())

--- a/src/machine_runner.py
+++ b/src/machine_runner.py
@@ -9,9 +9,8 @@ from typing import Any, Dict
 import httpx
 from colorama import Fore, Style
 from colorama import init as colorama_init
-
-# from lmcache.experimental.cache_engine import LMCacheEngineBuilder
-# from lmcache.integration.vllm.utils import ENGINE_NAME
+from lmcache.experimental.cache_engine import LMCacheEngineBuilder
+from lmcache.integration.vllm.utils import ENGINE_NAME
 from transformers import AutoTokenizer
 
 # from lmcache.v1.cache_engine import LMCacheEngineBuilder
@@ -712,7 +711,7 @@ async def main():
         # Cancel background tasks
         heartbeat_task.cancel()
         gateway_task.cancel()
-        # LMCacheEngineBuilder.destroy(ENGINE_NAME)
+        LMCacheEngineBuilder.destroy(ENGINE_NAME)
         # debug_monitor_task.cancel()
         try:
             await heartbeat_task

--- a/src/utils/deployment_utils.py
+++ b/src/utils/deployment_utils.py
@@ -636,13 +636,13 @@ def create_dynamic_vllm_model(
 
     original_make_layers = model_utils.make_layers
     model_utils.make_layers = _selective_make_layers
-    # from vllm.config import KVTransferConfig
+    from vllm.config import KVTransferConfig
 
-    # ktc = KVTransferConfig(
-    #     kv_connector="LMCacheConnector",  # v0 connector
-    #     kv_role="kv_both",  # single process does store+retrieve
-    #     # For multi-process prefill/decode, use kv_producer/kv_consumer below
-    # )
+    ktc = KVTransferConfig(
+        kv_connector="LMCacheConnector",  # v0 connector
+        kv_role="kv_both",  # single process does store+retrieve
+        # For multi-process prefill/decode, use kv_producer/kv_consumer below
+    )
     # speculative_config = {
     #     "method": "ngram",
     #     "prompt_lookup_max": 5,
@@ -658,7 +658,7 @@ def create_dynamic_vllm_model(
             "gpu_memory_utilization": 0.9,
             "load_format": "dummy",
             "dtype": dtype or "float16",
-            # "kv_transfer_config": ktc,
+            "kv_transfer_config": ktc,
             "skip_tokenizer_init": False,
             "use_v2_block_manager": False,
             "max_model_len": 16400,

--- a/src/utils/inference_utils.py
+++ b/src/utils/inference_utils.py
@@ -8,9 +8,9 @@ from typing import Any, Dict, List, Optional
 import httpx  # type: ignore
 import numpy as np
 import torch
+from vllm import LLM  # type: ignore
 
 from src.utils.tensor_protocol_adapter import TensorTransport
-from vllm import LLM  # type: ignore
 
 # This global dictionary holds the actual tensor data, not futures
 # Key: request_id (str)
@@ -801,6 +801,12 @@ def register_inference_hooks(
 
             except Exception as e:
                 print(f"❌ Error in inference run for {batch_id}: {e}")
+                llm.reset_prefix_cache()
+                llm.llm_engine.reset_prefix_cache()
+                llm.llm_engine.reset_mm_cache()
+                print(
+                    f"start_inference_run [except] block - has_unfinished_requests: {llm.llm_engine.has_unfinished_requests()}"
+                )
                 import traceback
 
                 traceback.print_exc()

--- a/src/utils/inference_utils.py
+++ b/src/utils/inference_utils.py
@@ -807,6 +807,23 @@ def register_inference_hooks(
                 print(
                     f"start_inference_run [except] block - has_unfinished_requests: {llm.llm_engine.has_unfinished_requests()}"
                 )
+
+                # Abort all pending requests in the LLM engine
+                all_request_ids = []
+
+                for scheduler in llm.llm_engine.scheduler:
+                    # Get request IDs from all three queues
+                    for seq_group in scheduler.waiting:
+                        all_request_ids.append(seq_group.request_id)
+                    for seq_group in scheduler.running:
+                        all_request_ids.append(seq_group.request_id)
+                    for seq_group in scheduler.swapped:
+                        all_request_ids.append(seq_group.request_id)
+
+                # Abort all collected request IDs at once
+                if all_request_ids:
+                    llm.llm_engine.abort_request(all_request_ids)
+
                 import traceback
 
                 traceback.print_exc()


### PR DESCRIPTION
- Added additional cleanup behaviour in the `except` section of `start_inference_run`.This will ensure that the llm object can be reused for the next inference.
- Passed sampler output back to all middle peers, to prevent crash when 1 request in batch terminates
- Streaming now terminates per request, no waiting till batch completes