### PR TITLE
[overhaul] Inflight batching

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -933,7 +933,6 @@ async def deploy_model(request: ModelDeploymentRequest):
         for peer_id, instructions in deployment_instructions.items():
             print(f"🔍 Engine args: {instructions['engine_args']}")
             payload_dict = {
-                "action": "deploy_model",
                 "target_peer_id": peer_id,  # fix this if needed
                 "instructions": instructions,
             }
@@ -1181,7 +1180,6 @@ async def send_batch(batch_id: str, model_name: str, queue: List[Request]):
     pipeline = list(deployment_map.keys())
 
     inference_payload = {
-        "action": "start_inference",  # ? Is this action spurious since it's sent to the infer endpoint
         "batch_id": batch_id,
         "model_name": model_name,
         "input_text": [req.prompt for req in queue],

--- a/src/utils/message_processing.py
+++ b/src/utils/message_processing.py
@@ -167,6 +167,11 @@ def validate_request_message(msg: Dict[str, Any]) -> bool:
     return all(field in msg for field in required_fields)
 
 
+def validate_dispatch_message(msg: Dict[str, Any]) -> bool:
+    required_fields = ["batch_id", "request_id"]
+    return all(field in msg for field in required_fields)
+
+
 def log_message_received(message_type: str, msg: Dict[str, Any], extra_info: str = ""):
     """
     Standardized logging for received messages.
@@ -207,5 +212,13 @@ def parse_request_message(tensor) -> Optional[Dict[str, Any]]:
     """Parse and validate incoming request message"""
     msg = parse_json_from_tensor(tensor)
     if msg and validate_request_message(msg):
+        return msg
+    return None
+
+
+def parse_dispatch_message(tensor) -> Optional[Dict[str, Any]]:
+    """Parse and validate incoming batch dispatch message"""
+    msg = parse_json_from_tensor(tensor)
+    if msg and validate_dispatch_message(msg):
         return msg
     return None

--- a/src/utils/req_batcher.py
+++ b/src/utils/req_batcher.py
@@ -24,6 +24,7 @@ class Batcher:
         self.max_req = max_req
         self.max_time = max_time
         self.process_req_fn = process_req_fn
+        self.busy = False  # Indicates if an inference is going on right now
 
         self._queue = []
         self._attr_lock = asyncio.Lock()
@@ -34,18 +35,34 @@ class Batcher:
     # Add request to the queue
     async def add(self, req: Request) -> None:
         async with self._attr_lock:
-            self._queue.append(req)
+            self._queue.append((req, time.monotonic()))
 
-            # First in queue, start timer
-            if len(self._queue) == 1:
-                self._start_time = time.monotonic()
-                self._timer_task = asyncio.create_task(self._timer_coro())
+            # If no inference going on
+            if not self.busy:
+                # First in queue, start timer
+                if len(self._queue) == 1:
+                    self._start_time = time.monotonic()
+                    self._timer_task = asyncio.create_task(self._timer_coro())
 
-            # Queue is now filled
-            elif len(self._queue) >= self.max_req:
+                # Queue is now filled
+                elif len(self._queue) >= self.max_req:
+                    self.flush_req()
+
+                # Otherwise, just wait for timer or more requests
+
+            # If busy, just adds and exits
+
+    # Clear the busy status - Will flush out another batch if batch is full OR oldest req has waited long enough
+    async def busy_clear(self):
+        async with self._attr_lock:
+            self.busy = False
+            # Send out batch if queue can fill out batch
+            if len(self._queue) >= self.max_req:
                 self.flush_req()
-
-            # Otherwise, just wait for timer or more requests
+            # If there is queue but not full, check if time is up (will instantly flush if time is up)
+            elif len(self._queue):
+                self._timer_task = asyncio.create_task(self._timer_coro())
+            # If no queue, do nothing other than set busy flag to False
 
     # Wait till we hit timeout
     async def _timer_coro(self) -> None:
@@ -66,15 +83,22 @@ class Batcher:
             self._timer_task.cancel()
             self._timer_task = None
 
-        self._start_time = None
+        # Take batch size out of queue and remove from queue
+        queue = self._queue[: self.max_req].copy()
+        del self._queue[: self.max_req]
 
-        queue = self._queue.copy()
-        self._queue.clear()
+        # Update start time with head of queue if any
+        if len(self._queue):
+            self._start_time = self._queue[0][1]
+        else:
+            self._start_time = None
 
         try:
             task = asyncio.create_task(
                 self.process_req_fn(
-                    batch_id=str(uuid.uuid4()), model_name=self.model_name, queue=queue
+                    batch_id=str(uuid.uuid4()),
+                    model_name=self.model_name,
+                    queue=[item[0] for item in queue],
                 )
             )
             self._inflight.add(task)
@@ -88,6 +112,9 @@ class Batcher:
                     )
 
             task.add_done_callback(_done)
+
+            # Update busy status
+            self.busy = True
 
         except Exception as e:
             print(f"Error creating task in batcher: {e}")
@@ -106,9 +133,10 @@ class Batcher:
                 self._timer_task.cancel()
                 self._timer_task = None
 
-            # Process any remaining requests in queue
-            if self._queue:
-                self.flush_req()
+            # Continuously batch remaining requests and create one task each
+            while self._queue:
+                with self._attr_lock:
+                    self.flush_req()
 
         # Wait for all inflight tasks to complete
         if self._inflight:

--- a/src/utils/req_batcher.py
+++ b/src/utils/req_batcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 import uuid
 from collections.abc import Coroutine
@@ -26,6 +27,7 @@ class Batcher:
         self.process_req_fn = process_req_fn
         self.busy = False  # Indicates if an inference is going on right now
 
+        self._loop = asyncio.get_running_loop()
         self._queue = []
         self._attr_lock = asyncio.Lock()
         self._start_time = None
@@ -36,16 +38,23 @@ class Batcher:
     async def add(self, req: Request) -> None:
         async with self._attr_lock:
             self._queue.append((req, time.monotonic()))
+            if len(self._queue) == 1:
+                self._start_time = time.monotonic()
+
+            print(f"batcher add() - len(queue): {len(self._queue)}")
 
             # If no inference going on
             if not self.busy:
+                print("batcher add() - not busy")
+                print(f"batcher add() - timer {self._timer_task}")
                 # First in queue, start timer
                 if len(self._queue) == 1:
-                    self._start_time = time.monotonic()
+                    print("batcher add() - not busy - started timer")
                     self._timer_task = asyncio.create_task(self._timer_coro())
 
                 # Queue is now filled
                 elif len(self._queue) >= self.max_req:
+                    print("batcher add() - not busy - full send")
                     self.flush_req()
 
                 # Otherwise, just wait for timer or more requests
@@ -53,32 +62,49 @@ class Batcher:
             # If busy, just adds and exits
 
     # Clear the busy status - Will flush out another batch if batch is full OR oldest req has waited long enough
+    # Have to be super careful! This function is called from a different thread
     async def busy_clear(self):
         async with self._attr_lock:
+            print(
+                f"batcher busy_clear() - len: {len(self._queue)}, queue: {self._queue}"
+            )
+            print(
+                f"THREAD - {threading.current_thread().name}, {threading.current_thread().ident}"
+            )
+            print(f"LOOP - {id(self._loop)}, {self._loop}")
             self.busy = False
             # Send out batch if queue can fill out batch
             if len(self._queue) >= self.max_req:
+                print("batcher busy_clear() - full send")
                 self.flush_req()
             # If there is queue but not full, check if time is up (will instantly flush if time is up)
             elif len(self._queue):
+                print("batcher busy_clear() - no full, timer")
                 self._timer_task = asyncio.create_task(self._timer_coro())
+                print("batcher busy_clear() - post _timer_coro() creation")
+                print(asyncio.all_tasks())
             # If no queue, do nothing other than set busy flag to False
 
     # Wait till we hit timeout
     async def _timer_coro(self) -> None:
         try:
             diff = time.monotonic() - self._start_time
+            print(f"batcher _timer_coro() - diff: {diff}")
             if diff < self.max_time:
                 await asyncio.sleep(self.max_time - diff)
 
             async with self._attr_lock:
+                print("batcher _timer_coro() - Timer hit, flushing")
                 self.flush_req()
 
         except asyncio.CancelledError:
             pass  # Do nothing since cancel is intentional
+        except:
+            raise
 
     # This function is only called when lock is held
     def flush_req(self) -> None:
+        print(f"batcher flush_req() - timer task {self._timer_task}")
         if self._timer_task:
             self._timer_task.cancel()
             self._timer_task = None


### PR DESCRIPTION
## Changed the batching architecture. 

### Old
- server batches request based on batch size + timeout, whichever comes first
- batches then gets sent out to the peer
- individual peer queues the batches (not the requests!) and runs them in serial

### Problems
- suppose the timeout for pushing out a batch is 1s
- If the incoming RPS is also about ~1/s, then we are continuously sending out "batches" of 1 request
- the peer then keeps running "batches" of 1 request instead of an actual full batch
- __Key idea:__ While peer is busy running an inference, we can fill the batch more

### New
- responsibility for batching requests is moved to the first peer in the chain
- server sends out requests to all peers as they come in
- peer 1 maintains a batcher object that follows the following idea:
  - If chain is not busy, fill up batch till timeout (same as old idea)
  - If chain is busy, add requests to queue and only form batch when chain stops being busy (that way you can maximize the number of requests in the batch)
- peer 1 sends out batching decisions ( basically batch_id -> List(request_id) ) to all peers as well as server